### PR TITLE
Make the hashtag actually a hashtag

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -19,7 +19,7 @@
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     
     <!-- General app strings -->
-    <string name="freedomhub_title">#Lets Aim-ify</string>
+    <string name="freedomhub_title">#LetsAIMify</string>
     <string name="add">Add</string>
     <string name="advanced">Advanced</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
`#Lets Aim-ify` is not a valid hashtag, and doesn't even use the proper capitalization of AIM